### PR TITLE
set up wagtail_feeds to provide rss for discourse topic creation

### DIFF
--- a/geekbeacon/settings/base.py
+++ b/geekbeacon/settings/base.py
@@ -55,6 +55,7 @@ INSTALLED_APPS = [
     'wagtail.contrib.forms',
     'wagtail.contrib.redirects',
     'wagtail.contrib.routable_page',
+    'wagtail.contrib.settings',
     'wagtail.embeds',
     'wagtail.sites',
     'wagtail.users',
@@ -64,6 +65,7 @@ INSTALLED_APPS = [
     'wagtail.search',
     'wagtail.admin',
     'wagtail.core',
+    'wagtail_feeds',
 
     'modelcluster',
     'taggit',
@@ -112,7 +114,7 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'geekbeacon.wsgi.application'
 
-ALLOWED_HOSTS = env.list('DJANGO_ALLOWED_HOSTS', default=['geekbeacon.org', '0.0.0.0',])
+ALLOWED_HOSTS = env.list('DJANGO_ALLOWED_HOSTS', default=['geekbeacon.org', '0.0.0.0', 'localhost'])
 
 
 

--- a/geekbeacon/urls.py
+++ b/geekbeacon/urls.py
@@ -7,6 +7,7 @@ from django.contrib import admin
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.core import urls as wagtail_urls
 from wagtail.documents import urls as wagtaildocs_urls
+from wagtail_feeds.feeds import BasicFeed
 
 from search import views as search_views
 
@@ -18,6 +19,8 @@ urlpatterns = [
     url(r'^documents/', include(wagtaildocs_urls)),
 
     url(r'^search/$', search_views.search, name='search'),
+
+    url(r'^rss$', BasicFeed(), name='basic_feed'),
 
     # For anything not caught by a more specific rule above, hand over to
     # Wagtail's page serving mechanism. This should be the last pattern in

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,3 +5,4 @@ django-environ>=0.4,<0.5
 django-extensions>=1.9,<2.1
 Werkzeug>=0.12,<0.13
 whitenoise==3.3.0
+django-wagtail-feeds==0.1.0


### PR DESCRIPTION
discourse will poll the rss feed for new posts and create new topics accordingly, the topics are to serve as the sources for the embeddable comments at the bottom of blog posts